### PR TITLE
Regress bunshi version to `~2.0.2` in `@raisins/react`

### DIFF
--- a/.changeset/young-zebras-tease.md
+++ b/.changeset/young-zebras-tease.md
@@ -1,0 +1,5 @@
+---
+"@raisins/react": patch
+---
+
+Regress to bunshi@2.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -12239,26 +12239,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "node_modules/bunshi": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/bunshi/-/bunshi-2.1.4.tgz",
-      "integrity": "sha512-8kHpSsfFQu3Dj6nuVP5qr6wwqeXHbdu/hqrT1hdv6N4KcIQ0amHJYR0iSgjYhxazS6NlQb6JacP1/A7EJ+ZRAg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "vue": ">=3"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -39007,7 +38987,7 @@
       "dependencies": {
         "@raisins/core": "^1.1.3",
         "@raisins/schema": "^1.0.0",
-        "bunshi": "^2.1.4",
+        "bunshi": "~2.0.2",
         "css-tree": "^1.1.3",
         "fast-equals": "^5.0.1",
         "hotkeys-js": "^3.8.7",
@@ -40715,6 +40695,26 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/react/node_modules/bunshi": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bunshi/-/bunshi-2.0.2.tgz",
+      "integrity": "sha512-bsYQT1KJPVQ+8JFDcB5gHZgmvlRXGCu46cR9qZTKsM8GNAOJXmjAYXuePkJt7bQYxrUNw7ub4OSwnImMkPvPhQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "vue": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "packages/react/node_modules/chokidar": {
@@ -48489,7 +48489,7 @@
         "@types/styled-components": "^5.1.14",
         "@types/throttle-debounce": "^5.0.0",
         "babel-loader": "^8.2.2",
-        "bunshi": "^2.1.4",
+        "bunshi": "~2.0.2",
         "css-tree": "^1.1.3",
         "custom-elements-manifest": "^1.0.0",
         "cypress": "^12.12.0",
@@ -49732,6 +49732,12 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "bunshi": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bunshi/-/bunshi-2.0.2.tgz",
+          "integrity": "sha512-bsYQT1KJPVQ+8JFDcB5gHZgmvlRXGCu46cR9qZTKsM8GNAOJXmjAYXuePkJt7bQYxrUNw7ub4OSwnImMkPvPhQ==",
+          "requires": {}
         },
         "chokidar": {
           "version": "3.5.3",
@@ -57645,12 +57651,6 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
-    },
-    "bunshi": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/bunshi/-/bunshi-2.1.4.tgz",
-      "integrity": "sha512-8kHpSsfFQu3Dj6nuVP5qr6wwqeXHbdu/hqrT1hdv6N4KcIQ0amHJYR0iSgjYhxazS6NlQb6JacP1/A7EJ+ZRAg==",
-      "requires": {}
     },
     "bytes": {
       "version": "3.1.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@raisins/core": "^1.1.3",
     "@raisins/schema": "^1.0.0",
-    "bunshi": "^2.1.4",
+    "bunshi": "~2.0.2",
     "css-tree": "^1.1.3",
     "fast-equals": "^5.0.1",
     "hotkeys-js": "^3.8.7",


### PR DESCRIPTION
## Description of the change

> Regresses the version of `bunshi` to `~2.0.2` within `@raisins/react` to avoid any issues with `2.1.x` until it is stable with raisins.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
