### PR TITLE
[Fix] Allow examples with styled wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,24 @@
         "serve": "^12.0.1"
       }
     },
+    "examples/my-kitchen-sink/node_modules/@raisins/schema": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@raisins/schema/-/schema-1.1.0.tgz",
+      "integrity": "sha512-2iJ55xu+h+GluW86YJB+kuOIOESk90sEHOR9UuzKSguWGntxtoFEUeWjca2oUZKjv5VB2l13GoRV47AQXrKhJQ==",
+      "dev": true
+    },
+    "examples/my-kitchen-sink/node_modules/@raisins/stencil-docs-target": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@raisins/stencil-docs-target/-/stencil-docs-target-1.1.0.tgz",
+      "integrity": "sha512-R+r3iKKSgsytHmCFzVQbqx+UKBQj82yxQzForGtWi3F2L4m6IRNYG027paXGnhZnHh2iCFlX0s0kCAQjbYFK4A==",
+      "dev": true,
+      "dependencies": {
+        "@raisins/schema": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -38263,10 +38281,10 @@
     },
     "packages/core": {
       "name": "@raisins/core",
-      "version": "1.1.4",
+      "version": "1.1.5-1",
       "license": "MIT",
       "dependencies": {
-        "@raisins/schema": "^1.1.0",
+        "@raisins/schema": "^1.1.1-0",
         "color2k": "^2.0.0",
         "css": "^3.0.0",
         "css-select": "^5.1.0",
@@ -38396,11 +38414,11 @@
     },
     "packages/react": {
       "name": "@raisins/react",
-      "version": "1.3.0",
+      "version": "1.3.1-0",
       "license": "MIT",
       "dependencies": {
-        "@raisins/core": "^1.1.4",
-        "@raisins/schema": "^1.1.0",
+        "@raisins/core": "^1.1.5-1",
+        "@raisins/schema": "^1.1.1-0",
         "@storybook/cli": "^7.0.21",
         "bunshi": "~2.0.2",
         "css-tree": "^1.1.3",
@@ -41146,7 +41164,7 @@
     },
     "packages/schema": {
       "name": "@raisins/schema",
-      "version": "1.1.0",
+      "version": "1.1.1-0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^8.57.0",
@@ -41860,10 +41878,10 @@
     },
     "packages/stencil-docs-target": {
       "name": "@raisins/stencil-docs-target",
-      "version": "1.1.0",
+      "version": "1.1.1-0",
       "license": "MIT",
       "dependencies": {
-        "@raisins/schema": "^1.1.0"
+        "@raisins/schema": "^1.1.1-0"
       },
       "devDependencies": {
         "@eslint/js": "^8.57.0",
@@ -45587,6 +45605,23 @@
         "@stencil/core": "^2.7.0",
         "npm-run-all": "^4.1.5",
         "serve": "^12.0.1"
+      },
+      "dependencies": {
+        "@raisins/schema": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@raisins/schema/-/schema-1.1.0.tgz",
+          "integrity": "sha512-2iJ55xu+h+GluW86YJB+kuOIOESk90sEHOR9UuzKSguWGntxtoFEUeWjca2oUZKjv5VB2l13GoRV47AQXrKhJQ==",
+          "dev": true
+        },
+        "@raisins/stencil-docs-target": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@raisins/stencil-docs-target/-/stencil-docs-target-1.1.0.tgz",
+          "integrity": "sha512-R+r3iKKSgsytHmCFzVQbqx+UKBQj82yxQzForGtWi3F2L4m6IRNYG027paXGnhZnHh2iCFlX0s0kCAQjbYFK4A==",
+          "dev": true,
+          "requires": {
+            "@raisins/schema": "^1.1.0"
+          }
+        }
       }
     },
     "@fal-works/esbuild-plugin-global-externals": {
@@ -46253,7 +46288,7 @@
     "@raisins/core": {
       "version": "file:packages/core",
       "requires": {
-        "@raisins/schema": "^1.1.0",
+        "@raisins/schema": "^1.1.1-0",
         "@saasquatch/scoped-autobindsteps": "^1.0.0",
         "@shoelace-style/react": "^2.0.0-beta.52",
         "@size-limit/preset-small-lib": "^5.0.4",
@@ -46356,8 +46391,8 @@
         "@babel/core": "^7.15.5",
         "@eslint/js": "^8.57.0",
         "@mdx-js/react": "^2.1.1",
-        "@raisins/core": "^1.1.4",
-        "@raisins/schema": "^1.1.0",
+        "@raisins/core": "^1.1.5-1",
+        "@raisins/schema": "1.1.1-0",
         "@size-limit/preset-small-lib": "^5.0.4",
         "@storybook/addons": "^7.0.21",
         "@storybook/cli": "^7.0.21",
@@ -48782,7 +48817,7 @@
       "version": "file:packages/stencil-docs-target",
       "requires": {
         "@eslint/js": "^8.57.0",
-        "@raisins/schema": "^1.1.0",
+        "@raisins/schema": "^1.1.1-0",
         "@size-limit/preset-small-lib": "^5.0.4",
         "@stencil/core": "^2.8.1",
         "@types/jest": "^27.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@raisins/core",
   "author": "ReferralSaaSquatch.com, Inc.",
   "description": "Core functions for manipulating and validating HTML and raisin nodes",
-  "version": "1.1.4",
+  "version": "1.1.5-1",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/core.esm.js",
@@ -73,7 +73,7 @@
     "typescript": "^3.9.10"
   },
   "dependencies": {
-    "@raisins/schema": "^1.1.0",
+    "@raisins/schema": "^1.1.1-0",
     "color2k": "^2.0.0",
     "css": "^3.0.0",
     "css-select": "^5.1.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@raisins/react",
   "author": "ReferralSaaSquatch.com, Inc.",
   "description": "React package with tools for building a Raisins editor",
-  "version": "1.3.0",
+  "version": "1.3.1-3",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/react.esm.js",
@@ -55,8 +55,8 @@
     }
   ],
   "dependencies": {
-    "@raisins/core": "^1.1.4",
-    "@raisins/schema": "^1.1.0",
+    "@raisins/core": "^1.1.5-1",
+    "@raisins/schema": "^1.1.1-0",
     "@storybook/cli": "^7.0.21",
     "bunshi": "~2.0.2",
     "css-tree": "^1.1.3",

--- a/packages/react/src/component-metamodel/ComponentModel.tsx
+++ b/packages/react/src/component-metamodel/ComponentModel.tsx
@@ -109,6 +109,7 @@ export const ComponentModelMolecule = molecule(
         return {
           title: block.title,
           content: blockFromHtml(block.examples?.[0]?.content as string),
+          exampleGroup: block.exampleGroup,
         };
       }) as Block[];
       return [...blocksFromModules, ...defaultBlocks];
@@ -328,6 +329,7 @@ function group(list: Block[], getComponentMeta: Function): BlockGroups {
   return list.reduce(function(allGroups: BlockGroups, block: Block) {
     const exampleGroup =
       getComponentMeta(block.content?.tagName)?.exampleGroup ??
+      block.exampleGroup ??
       DEFAULT_BLOCK_GROUP;
     const groupArray = allGroups[exampleGroup] ?? [];
     const withBlock = [...groupArray, block];
@@ -344,6 +346,7 @@ function group(list: Block[], getComponentMeta: Function): BlockGroups {
 export type Block = {
   title: string;
   content: RaisinElementNode;
+  exampleGroup?: string;
 };
 
 export type ComponentModel = {

--- a/packages/react/src/component-metamodel/convert/moduleDetailsToBlocks.tsx
+++ b/packages/react/src/component-metamodel/convert/moduleDetailsToBlocks.tsx
@@ -6,7 +6,7 @@ import { ModuleDetails } from '../types';
 /**
  * Converts module details into a set of `Block`
  *
- * Blocks are used for inserting example content into Raisin
+ * Blocks are used for inserting example content into Raisins
  *
  * @param moduleDetails
  * @returns
@@ -40,6 +40,7 @@ function reduceExamples(
   const blockExample = {
     title: currentValue.title,
     content: elm,
+    exampleGroup: currentValue.exampleGroup,
   };
   return [...previousValue, blockExample];
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raisins/schema",
-  "version": "1.1.0",
+  "version": "1.1.1-0",
   "description": "Types (a.k.a. schema) for the Raisins ecosystem",
   "author": "ReferralSaaSquatch.com, Inc.",
   "license": "MIT",

--- a/packages/schema/schema.d.ts
+++ b/packages/schema/schema.d.ts
@@ -15,6 +15,7 @@ export interface Package {
 export type Example = {
   title: string;
   content: string;
+  exampleGroup?: string;
 };
 
 // Custom element modules

--- a/packages/stencil-docs-target/package.json
+++ b/packages/stencil-docs-target/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raisins/stencil-docs-target",
   "description": "A custom docs target for Stencil components. Edit in Raisins.",
-  "version": "1.1.0",
+  "version": "1.1.1-0",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",
   "module": "dist/stencil-docs-target.esm.js",
@@ -66,6 +66,6 @@
   },
   "homepage": "https://github.com/saasquatch/raisins",
   "dependencies": {
-    "@raisins/schema": "^1.1.0"
+    "@raisins/schema": "^1.1.1-0"
   }
 }

--- a/packages/stencil-docs-target/src/convertToRaisins.ts
+++ b/packages/stencil-docs-target/src/convertToRaisins.ts
@@ -71,12 +71,13 @@ export function convertToGrapesJSMeta(docs: JsonDocs): schema.Module {
               const [title, content] = splitOnFirst(d.text ?? '', ' - ');
               if (!title || !content) {
                 throw new Error(
-                  `Invalid example om ${comp.tag} is missing a title or content`
+                  `Invalid example on ${comp.tag} is missing a title or content`
                 );
               }
               return {
                 title,
                 content,
+                exampleGroup: tagValue(comp.docsTags, 'exampleGroup'),
               };
             }),
           demoStates: demos.length > 0 ? demos : undefined,


### PR DESCRIPTION
## Description of the change

> Examples with wrappers that were different than the component's tag name were not being grouped with the component they were defined in

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
