### PR TITLE
feat(css-editing): per-instance and document-wide CSS editing

### DIFF
--- a/packages/core/src/css-om/scope.iso.test.ts
+++ b/packages/core/src/css-om/scope.iso.test.ts
@@ -65,6 +65,36 @@ describe("scopeStylesheet", () => {
     );
   });
 
+  it("expands nested & in ::part pseudoclasses", () => {
+    expect(
+      scoped("::part(primarybutton-base){&:hover{background-color: blue}}")
+    ).toEqual(
+      '[data-raisin-id="abc"]::part(primarybutton-base):hover{background-color:blue}'
+    );
+  });
+
+  it("expands nested & with mixed declarations and nested rules", () => {
+    expect(
+      scoped("::part(button){color:red;&:hover{background:blue}}")
+    ).toEqual(
+      '[data-raisin-id="abc"]::part(button){color:red}[data-raisin-id="abc"]::part(button):hover{background:blue}'
+    );
+  });
+
+  it("expands multiple nested rules", () => {
+    expect(
+      scoped("::part(btn){&:hover{background:blue}&:focus{outline:none}}")
+    ).toEqual(
+      '[data-raisin-id="abc"]::part(btn):hover{background:blue}[data-raisin-id="abc"]::part(btn):focus{outline:none}'
+    );
+  });
+
+  it("expands nested & in :host rules", () => {
+    expect(scoped(":host{&:hover{color:red}}")).toEqual(
+      '[data-raisin-id="abc"]:hover{color:red}'
+    );
+  });
+
   it("does not mutate the input AST", () => {
     const ast = parser(":host { color: red }");
     const before = JSON.stringify(ast);

--- a/packages/core/src/css-om/scope.iso.test.ts
+++ b/packages/core/src/css-om/scope.iso.test.ts
@@ -1,0 +1,74 @@
+import expect from "expect";
+import parser from "./parser";
+import serializer from "./serializer";
+import { scopeStylesheet } from "./scope";
+
+function scoped(css: string, id = "abc"): string {
+  return serializer(scopeStylesheet(parser(css), id));
+}
+
+describe("scopeStylesheet", () => {
+  it("rewrites :host to the attribute selector", () => {
+    expect(scoped(":host { color: red }")).toEqual(
+      '[data-raisin-id="abc"]{color:red}'
+    );
+  });
+
+  it("rewrites :host(<sel>) by fusing the inner selector", () => {
+    expect(scoped(":host(.dark) { color: white }")).toEqual(
+      '[data-raisin-id="abc"].dark{color:white}'
+    );
+  });
+
+  it("rewrites :host(<sel>) with descendant combinators", () => {
+    expect(scoped(":host(.dark) > div { color: white }")).toEqual(
+      '[data-raisin-id="abc"].dark>div{color:white}'
+    );
+  });
+
+  it("prefixes ::part(name) with the scope attribute selector", () => {
+    expect(scoped("::part(button) { color: red }")).toEqual(
+      '[data-raisin-id="abc"]::part(button){color:red}'
+    );
+  });
+
+  it("preserves trailing pseudos on ::part", () => {
+    expect(scoped("::part(button):hover { color: red }")).toEqual(
+      '[data-raisin-id="abc"]::part(button):hover{color:red}'
+    );
+  });
+
+  it("rewrites bare selectors as descendants of the scope", () => {
+    expect(scoped(".foo { color: red }")).toEqual(
+      '[data-raisin-id="abc"] .foo{color:red}'
+    );
+  });
+
+  it("rewrites every selector in a selector list", () => {
+    expect(scoped(":host, .foo, ::part(x) { color: red }")).toEqual(
+      '[data-raisin-id="abc"],[data-raisin-id="abc"] .foo,[data-raisin-id="abc"]::part(x){color:red}'
+    );
+  });
+
+  it("rewrites rules nested inside at-rules", () => {
+    expect(
+      scoped("@media (min-width: 100px) { :host { color: red } }")
+    ).toEqual(
+      '@media (min-width:100px){[data-raisin-id="abc"]{color:red}}'
+    );
+  });
+
+  it("handles multiple rules in a stylesheet", () => {
+    const css = ":host { color: red } .bar { color: blue }";
+    expect(scoped(css)).toEqual(
+      '[data-raisin-id="abc"]{color:red}[data-raisin-id="abc"] .bar{color:blue}'
+    );
+  });
+
+  it("does not mutate the input AST", () => {
+    const ast = parser(":host { color: red }");
+    const before = JSON.stringify(ast);
+    scopeStylesheet(ast, "abc");
+    expect(JSON.stringify(ast)).toEqual(before);
+  });
+});

--- a/packages/core/src/css-om/scope.iso.test.ts
+++ b/packages/core/src/css-om/scope.iso.test.ts
@@ -53,9 +53,7 @@ describe("scopeStylesheet", () => {
   it("rewrites rules nested inside at-rules", () => {
     expect(
       scoped("@media (min-width: 100px) { :host { color: red } }")
-    ).toEqual(
-      '@media (min-width:100px){[data-raisin-id="abc"]{color:red}}'
-    );
+    ).toEqual('@media (min-width:100px){[data-raisin-id="abc"]{color:red}}');
   });
 
   it("handles multiple rules in a stylesheet", () => {

--- a/packages/core/src/css-om/scope.ts
+++ b/packages/core/src/css-om/scope.ts
@@ -1,0 +1,109 @@
+// eslint-disable-next-line prettier/prettier
+import { CssNodePlain, parse, toPlainObject } from "css-tree";
+
+/**
+ * Rewrites every selector in a stylesheet AST so that the rules apply only to
+ * the element marked with `data-raisin-id="<scope>"`.
+ *
+ * - `:host` and `:host(<sel>)` are replaced with the scope's attribute selector
+ *   (optionally fused with `<sel>`).
+ * - `::part(name)` selectors are prefixed with the scope attribute selector,
+ *   so the rule pierces the shadow boundary on the scoped element only.
+ * - Bare selectors become descendants of the scope attribute selector.
+ *
+ * The stylesheet is not parsed or serialized — the caller controls that. The
+ * returned AST shares no structural references with the input.
+ */
+export function scopeStylesheet(
+  stylesheet: CssNodePlain,
+  scope: string
+): CssNodePlain {
+  const clone = JSON.parse(JSON.stringify(stylesheet));
+  visitRules(clone, (rule: any) => scopeRule(rule, scope));
+  return clone;
+}
+
+function visitRules(node: any, visit: (rule: any) => void): void {
+  if (!node) return;
+  if (node.type === "Rule") {
+    visit(node);
+    return;
+  }
+  if (Array.isArray(node.children)) {
+    node.children.forEach((c: any) => visitRules(c, visit));
+  }
+  if (node.block) visitRules(node.block, visit);
+}
+
+function scopeRule(rule: any, scope: string): void {
+  const prelude = rule.prelude;
+  if (!prelude || prelude.type !== "SelectorList") return;
+  if (!Array.isArray(prelude.children)) return;
+  prelude.children = prelude.children.map((sel: any) =>
+    scopeSelector(sel, scope)
+  );
+}
+
+function scopeSelector(selector: any, scope: string): any {
+  if (selector.type !== "Selector" || !Array.isArray(selector.children)) {
+    return selector;
+  }
+  const children: any[] = selector.children;
+  const first = children[0];
+  const rest = children.slice(1);
+  const attr = buildAttributeSelector(scope);
+
+  if (first && first.type === "PseudoClassSelector" && first.name === "host") {
+    const inner = extractHostInner(first);
+    return { ...selector, children: [attr, ...inner, ...rest] };
+  }
+
+  if (
+    first &&
+    first.type === "PseudoElementSelector" &&
+    first.name === "part"
+  ) {
+    return { ...selector, children: [attr, ...children] };
+  }
+
+  return {
+    ...selector,
+    children: [attr, descendantCombinator(), ...children]
+  };
+}
+
+/**
+ * `:host(.foo > div)` stores `.foo > div` as a single Raw child. Parse it
+ * back into a Selector and lift its children up so they become a part of the
+ * outer selector.
+ */
+function extractHostInner(host: any): any[] {
+  const inner = host.children;
+  if (!Array.isArray(inner) || inner.length === 0) return [];
+  const innerText = inner[0]?.value;
+  if (typeof innerText !== "string" || innerText.length === 0) return [];
+  const parsedSelector: any = toPlainObject(
+    parse(innerText, { context: "selector" })
+  );
+  if (
+    parsedSelector.type !== "Selector" ||
+    !Array.isArray(parsedSelector.children)
+  ) {
+    return [];
+  }
+  return parsedSelector.children;
+}
+
+function buildAttributeSelector(scope: string): any {
+  return {
+    type: "AttributeSelector",
+    name: { type: "Identifier", name: "data-raisin-id" },
+    matcher: "=",
+    value: { type: "String", value: `"${scope}"` },
+    flags: null
+  };
+}
+
+function descendantCombinator(): any {
+  return { type: "Combinator", name: " " };
+}

--- a/packages/core/src/css-om/scope.ts
+++ b/packages/core/src/css-om/scope.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line prettier/prettier
-import { CssNodePlain, parse, toPlainObject } from "css-tree";
+import csstree, { CssNodePlain, parse, toPlainObject } from "css-tree";
 
 /**
  * Rewrites every selector in a stylesheet AST so that the rules apply only to
@@ -10,6 +10,8 @@ import { CssNodePlain, parse, toPlainObject } from "css-tree";
  * - `::part(name)` selectors are prefixed with the scope attribute selector,
  *   so the rule pierces the shadow boundary on the scoped element only.
  * - Bare selectors become descendants of the scope attribute selector.
+ * - Nested rules using `&` (CSS Nesting syntax) are expanded and lifted to the
+ *   top level with the parent's scoped selector substituted for `&`.
  *
  * The stylesheet is not parsed or serialized — the caller controls that. The
  * returned AST shares no structural references with the input.
@@ -19,20 +21,62 @@ export function scopeStylesheet(
   scope: string
 ): CssNodePlain {
   const clone = JSON.parse(JSON.stringify(stylesheet));
-  visitRules(clone, (rule: any) => scopeRule(rule, scope));
+  processChildren(clone, scope);
   return clone;
 }
 
-function visitRules(node: any, visit: (rule: any) => void): void {
-  if (!node) return;
-  if (node.type === "Rule") {
-    visit(node);
-    return;
+function processChildren(node: any, scope: string): void {
+  if (!node || !Array.isArray(node.children)) return;
+  const result: any[] = [];
+  for (const child of node.children) {
+    if (child.type === "Rule") {
+      scopeRule(child, scope);
+      const { kept, lifted } = expandNesting(child);
+      if (kept.length > 0) {
+        child.block.children = kept;
+        result.push(child);
+      }
+      result.push(...lifted);
+    } else {
+      if (child.block) processChildren(child.block, scope);
+      result.push(child);
+    }
   }
-  if (Array.isArray(node.children)) {
-    node.children.forEach((c: any) => visitRules(c, visit));
+  node.children = result;
+}
+
+function expandNesting(rule: any): { kept: any[]; lifted: any[] } {
+  const block = rule.block;
+  if (!block || !Array.isArray(block.children))
+    return { kept: [], lifted: [] };
+
+  const selectorStr = serializeNode(rule.prelude);
+  const kept: any[] = [];
+  const lifted: any[] = [];
+
+  for (const child of block.children) {
+    if (
+      child.type === "Raw" &&
+      typeof child.value === "string" &&
+      child.value.includes("&")
+    ) {
+      const expanded = child.value.replace(/&/g, selectorStr);
+      const parsed: any = toPlainObject(parse(expanded));
+      if (parsed.type === "StyleSheet" && Array.isArray(parsed.children)) {
+        lifted.push(...parsed.children);
+      }
+    } else {
+      kept.push(child);
+    }
   }
-  if (node.block) visitRules(node.block, visit);
+
+  return { kept, lifted };
+}
+
+function serializeNode(node: any): string {
+  return csstree.generate(
+    csstree.fromPlainObject(JSON.parse(JSON.stringify(node)))
+  );
 }
 
 function scopeRule(rule: any, scope: string): void {

--- a/packages/core/src/css-om/scope.ts
+++ b/packages/core/src/css-om/scope.ts
@@ -47,8 +47,7 @@ function processChildren(node: any, scope: string): void {
 
 function expandNesting(rule: any): { kept: any[]; lifted: any[] } {
   const block = rule.block;
-  if (!block || !Array.isArray(block.children))
-    return { kept: [], lifted: [] };
+  if (!block || !Array.isArray(block.children)) return { kept: [], lifted: [] };
 
   const selectorStr = serializeNode(rule.prelude);
   const kept: any[] = [];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 import cssParser from "./css-om/parser";
+import { scopeStylesheet } from "./css-om/scope";
 import cssSerializer from "./css-om/serializer";
 import { StyleNodeProps, StyleNodeWithChildren } from "./css-om/Types";
 import * as cssUtil from "./css-om/util";
@@ -77,7 +78,8 @@ export {
   cssSerializer,
   cssParser,
   cssSelector,
-  cssUtil
+  cssUtil,
+  scopeStylesheet
 };
 export type {
   RaisinNodeVisitor,

--- a/packages/react/src/attributes/DefaultAttributeThemeMolecule.tsx
+++ b/packages/react/src/attributes/DefaultAttributeThemeMolecule.tsx
@@ -85,6 +85,24 @@ export const DefaultSelectWidget: AttributeWidget = () => {
   );
 };
 
+/**
+ * Raw CSS editor — round-trips the attribute value as-is. Used by attributes
+ * that store CSS (e.g. `data-raisin-css`) so consumers can opt into a CSS
+ * editing surface via `uiWidget: "css"`.
+ */
+export const DefaultCssWidget: AttributeWidget = () => {
+  const { valueAtom } = useMolecule(AttributeMolecule);
+  const [value, setValue] = useAtom(valueAtom);
+  return (
+    <textarea
+      rows={6}
+      style={{ width: '100%', fontFamily: 'monospace' }}
+      value={value ?? ''}
+      onChange={e => setValue((e.target as HTMLTextAreaElement).value)}
+    />
+  );
+};
+
 export const DefaultAttributeThemeMolecule = molecule<
   AttributeThemeMoleculeValue
 >(() => {
@@ -94,6 +112,7 @@ export const DefaultAttributeThemeMolecule = molecule<
       boolean: DefaultBooleanWidget,
       number: DefaultNumberWidget,
       select: DefaultSelectWidget,
+      css: DefaultCssWidget,
       [DefaultAttributeComponent]: DefaultTextWidget,
     }),
     templates: atom({

--- a/packages/react/src/canvas/CanvasScopeMolecule.tsx
+++ b/packages/react/src/canvas/CanvasScopeMolecule.tsx
@@ -8,6 +8,7 @@ import {
   SoulsInDocMolecule,
   SoulsMolecule,
 } from '../core';
+import { CssEditingMolecule } from '../css-editing/CssEditingMolecule';
 import { Soul } from '../core/souls/Soul';
 import { NPMRegistryAtom } from '../util/NPMRegistry';
 import {
@@ -62,6 +63,7 @@ export const CanvasScopeMolecule = molecule((getMol, getScope) => {
   const { IdToSoulAtom, SoulToNodeAtom } = getMol(SoulsInDocMolecule);
   const { rerenderNodeAtom } = getMol(CoreMolecule);
   const { PloppingIsActive } = getMol(PickAndPlopMolecule);
+  const { ManagedStyleSheetAtom } = getMol(CssEditingMolecule);
   const HTMLSet = new Set<Atom<string>>();
   const AppendersSet = new Set<Atom<SnabbdomAppender>>([]);
   const RendererSet = new Set<Atom<SnabbdomRenderer>>([]);
@@ -190,7 +192,11 @@ export const CanvasScopeMolecule = molecule((getMol, getScope) => {
     const bonus = Array.from(HTMLSet.values())
       .map(a => get(a))
       .join('');
-    return script + extra + bonus;
+    const managedCss = get(ManagedStyleSheetAtom);
+    const managedStyle = managedCss
+      ? `<style data-raisin-managed>${managedCss}</style>`
+      : '';
+    return script + extra + bonus + managedStyle;
   });
 
   const selector = atom(get => `[${get(EventSelectorAtom)}]`);

--- a/packages/react/src/css-editing/CssEditingMolecule.tsx
+++ b/packages/react/src/css-editing/CssEditingMolecule.tsx
@@ -1,0 +1,144 @@
+import {
+  cssParser,
+  cssSerializer,
+  htmlUtil,
+  RaisinElementNode,
+  RaisinNode,
+  scopeStylesheet,
+} from '@raisins/core';
+import { molecule } from 'bunshi/react';
+import { atom, Atom, PrimitiveAtom, WritableAtom } from 'jotai';
+import { CoreMolecule } from '../core/CoreAtoms';
+import { EditMolecule } from '../core/editting/EditAtoms';
+
+/**
+ * HTML attributes used by Raisins to mark elements that participate in
+ * per-instance CSS editing.
+ */
+export const RAISIN_CSS_ATTR = 'data-raisin-css';
+export const RAISIN_ID_ATTR = 'data-raisin-id';
+
+const { visit } = htmlUtil;
+
+/**
+ * Generates a short, stable-ish id for new `data-raisin-id` attributes. Not
+ * required to be cryptographically random — just unique enough that two
+ * elements on the same page do not collide.
+ */
+function generateId(): string {
+  return 'r' + Math.random().toString(36).slice(2, 10);
+}
+
+function isElement(n: RaisinNode): n is RaisinElementNode {
+  return n.type === 'tag';
+}
+
+function collectElementsWithInstanceCss(
+  root: RaisinNode
+): Array<{ id: string; css: string }> {
+  const collected: Array<{ id: string; css: string }> = [];
+  visit(root, {
+    onElement(el) {
+      const css = el.attribs[RAISIN_CSS_ATTR];
+      const id = el.attribs[RAISIN_ID_ATTR];
+      if (typeof css === 'string' && css.length > 0 && typeof id === 'string') {
+        collected.push({ id, css });
+      }
+      return el;
+    },
+    onRoot(_, __) {
+      return undefined;
+    },
+  });
+  return collected;
+}
+
+export type CssEditingMoleculeType = {
+  /**
+   * Page-wide CSS authored in the Document CSS editor. Persisted in the host
+   * application by whatever state plumbs `RootNodeAtom` — see
+   * {@link CssEditingMolecule} docs for the v1 trade-off.
+   */
+  DocumentCssAtom: PrimitiveAtom<string>;
+
+  /**
+   * The full CSS the canvas should render: page-wide CSS followed by all
+   * per-instance CSS, each scoped to the relevant `data-raisin-id`.
+   */
+  ManagedStyleSheetAtom: Atom<string>;
+
+  /**
+   * Reads the per-instance CSS for an element, falling back to "".
+   */
+  GetInstanceCssAtom: Atom<(node: RaisinElementNode) => string>;
+
+  /**
+   * Writes `data-raisin-css` (and assigns `data-raisin-id` if missing) for an
+   * element on the document tree. Pass `""` to clear.
+   */
+  SetInstanceCssAtom: WritableAtom<
+    null,
+    { node: RaisinElementNode; css: string },
+    void
+  >;
+};
+
+export const CssEditingMolecule = molecule(
+  (getMol): CssEditingMoleculeType => {
+    const { RootNodeAtom } = getMol(CoreMolecule);
+    const { ReplaceNodeAtom } = getMol(EditMolecule);
+
+    const DocumentCssAtom = atom<string>('');
+    DocumentCssAtom.debugLabel = 'DocumentCssAtom';
+
+    const ManagedStyleSheetAtom = atom(get => {
+      const root = get(RootNodeAtom);
+      const documentCss = get(DocumentCssAtom);
+      const instances = collectElementsWithInstanceCss(root);
+
+      const scopedParts = instances
+        .map(({ id, css }) => {
+          try {
+            return cssSerializer(scopeStylesheet(cssParser(css), id));
+          } catch {
+            return '';
+          }
+        })
+        .filter(part => part.length > 0);
+
+      return [documentCss, ...scopedParts].filter(s => s.length > 0).join('\n');
+    });
+    ManagedStyleSheetAtom.debugLabel = 'ManagedStyleSheetAtom';
+
+    const GetInstanceCssAtom = atom(() => {
+      return (node: RaisinElementNode): string => {
+        if (!isElement(node)) return '';
+        return node.attribs[RAISIN_CSS_ATTR] ?? '';
+      };
+    });
+
+    const SetInstanceCssAtom = atom(
+      null,
+      (_get, set, { node, css }: { node: RaisinElementNode; css: string }) => {
+        const nextAttribs = { ...node.attribs };
+        if (css.length === 0) {
+          delete nextAttribs[RAISIN_CSS_ATTR];
+        } else {
+          nextAttribs[RAISIN_CSS_ATTR] = css;
+          if (!nextAttribs[RAISIN_ID_ATTR]) {
+            nextAttribs[RAISIN_ID_ATTR] = generateId();
+          }
+        }
+        const nextNode: RaisinElementNode = { ...node, attribs: nextAttribs };
+        set(ReplaceNodeAtom, { prev: node, next: nextNode });
+      }
+    );
+
+    return {
+      DocumentCssAtom,
+      ManagedStyleSheetAtom,
+      GetInstanceCssAtom,
+      SetInstanceCssAtom,
+    };
+  }
+);

--- a/packages/react/src/css-editing/CssEditingMolecule.tsx
+++ b/packages/react/src/css-editing/CssEditingMolecule.tsx
@@ -78,7 +78,7 @@ export type CssEditingMoleculeType = {
    */
   SetInstanceCssAtom: WritableAtom<
     null,
-    { node: RaisinElementNode; css: string },
+    [{ node: RaisinElementNode; css: string }],
     void
   >;
 };

--- a/packages/react/src/css-editing/DocumentCssMolecule.tsx
+++ b/packages/react/src/css-editing/DocumentCssMolecule.tsx
@@ -1,0 +1,30 @@
+import { molecule, useMolecule } from 'bunshi/react';
+import { useAtom } from 'jotai';
+import React from 'react';
+import { CssEditingMolecule } from './CssEditingMolecule';
+
+/**
+ * Document-wide CSS editor. Reads and writes the same atom that drives the
+ * managed `<style>` block injected into the canvas iframe head.
+ */
+export const DocumentCssMolecule = molecule(getMol => {
+  const { DocumentCssAtom } = getMol(CssEditingMolecule);
+  return { DocumentCssAtom };
+});
+
+export const DocumentCssEditor: React.FC = () => {
+  const { DocumentCssAtom } = useMolecule(DocumentCssMolecule);
+  const [css, setCss] = useAtom(DocumentCssAtom);
+  return (
+    <div>
+      <h3>Document CSS</h3>
+      <textarea
+        rows={10}
+        style={{ width: '100%', fontFamily: 'monospace' }}
+        value={css}
+        placeholder={'sqm-hero { display: none; }'}
+        onChange={e => setCss(e.target.value)}
+      />
+    </div>
+  );
+};

--- a/packages/react/src/css-editing/StyleMolecule.tsx
+++ b/packages/react/src/css-editing/StyleMolecule.tsx
@@ -274,7 +274,6 @@ const SectionEditor: React.FC<{
     if (document.activeElement?.tagName !== 'TEXTAREA') {
       setDraft(persisted);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [persisted]);
 
   return (

--- a/packages/react/src/css-editing/StyleMolecule.tsx
+++ b/packages/react/src/css-editing/StyleMolecule.tsx
@@ -1,0 +1,247 @@
+import { RaisinElementNode } from '@raisins/core';
+import { CssPart, CustomElement } from '@raisins/schema/schema';
+import { molecule, useMolecule } from 'bunshi/react';
+import { atom, useAtom, useAtomValue } from 'jotai';
+import React, { useEffect, useState } from 'react';
+import { ComponentModelMolecule } from '../component-metamodel';
+import { SelectedNodeMolecule } from '../core/selection/SelectedNodeMolecule';
+import { isElementNode } from '../util/isNode';
+import { CssEditingMolecule } from './CssEditingMolecule';
+import {
+  readSection,
+  SectionKey,
+  selectorOf,
+  writeSection,
+} from './cssSections';
+
+/**
+ * Per-instance CSS editor for the currently selected element. Exposes:
+ *
+ * - `cssAtom` — read/write the full `data-raisin-css` value as a string
+ * - `partsAtom` — the list of `::part(name)` surfaces declared by the
+ *   element's component schema
+ * - `customPropsAtom` — the list of CSS custom properties declared by the
+ *   element's component schema
+ *
+ * Surface-specific editing (e.g. one rule per part) is left to UI; the
+ * molecule deliberately stops at the source-of-truth string so widgets can
+ * be composed freely.
+ */
+export const StyleMolecule = molecule(getMol => {
+  const { SelectedNodeAtom } = getMol(SelectedNodeMolecule);
+  const { ComponentMetaAtom } = getMol(ComponentModelMolecule);
+  const {
+    GetInstanceCssAtom,
+    SetInstanceCssAtom,
+  } = getMol(CssEditingMolecule);
+
+  const selectedElementAtom = atom(get => {
+    const node = get(SelectedNodeAtom);
+    if (!node || !isElementNode(node)) return undefined;
+    return node;
+  });
+
+  const componentMetaAtom = atom(get => {
+    const node = get(selectedElementAtom);
+    if (!node) return undefined;
+    return get(ComponentMetaAtom)(node.tagName) as CustomElement;
+  });
+
+  const partsAtom = atom<CssPart[]>(
+    get => get(componentMetaAtom)?.cssParts ?? []
+  );
+
+  const customPropsAtom = atom(get => get(componentMetaAtom)?.cssProperties ?? []);
+
+  const cssAtom = atom(
+    get => {
+      const node = get(selectedElementAtom);
+      if (!node) return '';
+      return get(GetInstanceCssAtom)(node);
+    },
+    (get, set, next: string) => {
+      const node = get(selectedElementAtom);
+      if (!node) return;
+      set(SetInstanceCssAtom, { node, css: next });
+    }
+  );
+
+  /**
+   * Returns the declarations text for a specific editable section
+   * (e.g. `:host` or `::part(header)`) of the currently selected element's
+   * per-instance CSS.
+   */
+  const sectionReadAtom = atom(get => {
+    const css = get(cssAtom);
+    return (section: SectionKey) => readSection(css, section);
+  });
+
+  /**
+   * Writes new declarations for a single section. Other sections (and any
+   * unrecognised rules) in the per-instance CSS are preserved untouched.
+   */
+  const sectionWriteAtom = atom(
+    null,
+    (
+      get,
+      set,
+      { section, declarations }: { section: SectionKey; declarations: string }
+    ) => {
+      const node = get(selectedElementAtom);
+      if (!node) return;
+      const prev = get(GetInstanceCssAtom)(node);
+      const next = writeSection(prev, section, declarations);
+      set(SetInstanceCssAtom, { node, css: next });
+    }
+  );
+
+  return {
+    selectedElementAtom,
+    componentMetaAtom,
+    partsAtom,
+    customPropsAtom,
+    cssAtom,
+    sectionReadAtom,
+    sectionWriteAtom,
+  };
+});
+
+/**
+ * Per-instance CSS editor. Renders one editable section for the element
+ * itself (`:host`) plus one section per declared `::part(name)`. Each
+ * section's textarea contains only declarations — the selector wrapper is
+ * applied automatically when the rule is rewritten in `data-raisin-css`.
+ *
+ * The component schema (`cssParts`, `cssProperties`) is also surfaced so
+ * authors can discover what surfaces are stylable on the selected component.
+ */
+export const StylePanel: React.FC = () => {
+  const {
+    selectedElementAtom,
+    partsAtom,
+    customPropsAtom,
+    cssAtom,
+  } = useMolecule(StyleMolecule);
+
+  const selected = useAtomValue(selectedElementAtom) as
+    | RaisinElementNode
+    | undefined;
+  const parts = useAtomValue(partsAtom);
+  const customProps = useAtomValue(customPropsAtom);
+  const css = useAtomValue(cssAtom);
+
+  if (!selected) return null;
+
+  return (
+    <div>
+      <h3>Style: {selected.tagName}</h3>
+
+      <SectionEditor
+        key={`element-${selected.tagName}-${selected.attribs['data-raisin-id'] ?? ''}`}
+        section={{ type: 'element' }}
+        title="Element"
+        description={`Applies to the component itself (rendered as :host).`}
+      />
+
+      {parts.map(part => (
+        <SectionEditor
+          key={`part-${part.name}-${selected.attribs['data-raisin-id'] ?? ''}`}
+          section={{ type: 'part', name: part.name }}
+          title={`::part(${part.name})`}
+          description={part.description}
+        />
+      ))}
+
+      {customProps.length > 0 && (
+        <details>
+          <summary>CSS custom properties</summary>
+          <ul>
+            {customProps.map(p => (
+              <li key={p.name}>
+                <code>{p.name}</code>
+                {p.syntax ? ` (${p.syntax})` : ''}
+                {p.description ? ` — ${p.description}` : ''}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      <details>
+        <summary>Raw CSS (data-raisin-css)</summary>
+        <pre style={{ fontSize: 11, whiteSpace: 'pre-wrap' }}>{css}</pre>
+      </details>
+    </div>
+  );
+};
+
+const SectionEditor: React.FC<{
+  section: SectionKey;
+  title: string;
+  description?: string;
+}> = ({ section, title, description }) => {
+  const { sectionReadAtom, sectionWriteAtom } = useMolecule(StyleMolecule);
+  const read = useAtomValue(sectionReadAtom);
+  const [, write] = useAtom(sectionWriteAtom);
+
+  // Keep the textarea fully controlled by local state. If we drove `value`
+  // from a parse-and-reformat of the stored CSS, every keystroke that produced
+  // a momentarily invalid declaration (e.g. mid-token `padding: 1`) would snap
+  // the field back to its last-valid form and clobber the caret. Local draft
+  // means the user always types into a normal textarea; writes to the atom
+  // are best-effort and silently no-op while the input is unparseable.
+  const [draft, setDraft] = useState(() => read(section));
+
+  // If the persisted CSS changes from outside (selection change handled by
+  // remount key; this covers a programmatic edit on the same element), only
+  // overwrite the draft when the field is not focused — never yank text out
+  // from under the user mid-keystroke.
+  const persisted = read(section);
+  useEffect(() => {
+    if (document.activeElement?.tagName !== 'TEXTAREA') {
+      setDraft(persisted);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [persisted]);
+
+  return (
+    <div style={SectionStyle}>
+      <div style={SectionHeaderStyle}>
+        <code>{selectorOf(section)}</code>
+        <span style={{ marginLeft: 6, color: '#888' }}>{title}</span>
+      </div>
+      {description && (
+        <div style={{ fontSize: 11, color: '#666' }}>{description}</div>
+      )}
+      <textarea
+        rows={4}
+        style={{ width: '100%', fontFamily: 'monospace', fontSize: 12 }}
+        value={draft}
+        placeholder={
+          section.type === 'element' ? ELEMENT_PLACEHOLDER : PART_PLACEHOLDER
+        }
+        onChange={e => {
+          const next = (e.target as HTMLTextAreaElement).value;
+          setDraft(next);
+          write({ section, declarations: next });
+        }}
+        onBlur={() => write({ section, declarations: draft })}
+      />
+    </div>
+  );
+};
+
+const SectionStyle: React.CSSProperties = {
+  border: '1px solid #ddd',
+  borderRadius: 4,
+  padding: 8,
+  marginBottom: 8,
+};
+
+const SectionHeaderStyle: React.CSSProperties = {
+  fontWeight: 600,
+  marginBottom: 4,
+};
+
+const ELEMENT_PLACEHOLDER = `padding: 16px;\ncolor: #222;`;
+const PART_PLACEHOLDER = `background: tomato;\ncolor: white;`;

--- a/packages/react/src/css-editing/StyleMolecule.tsx
+++ b/packages/react/src/css-editing/StyleMolecule.tsx
@@ -8,10 +8,9 @@ import { SelectedNodeMolecule } from '../core/selection/SelectedNodeMolecule';
 import { isElementNode } from '../util/isNode';
 import { CssEditingMolecule } from './CssEditingMolecule';
 import {
-  CssDimension,
   readSection,
-  readSectionDimension,
   readSectionShorthandDimension,
+  ReadSectionOptions,
   SectionKey,
   selectorOf,
   ShorthandDimensions,
@@ -27,16 +26,15 @@ export type StyleMoleculeType = {
     { name: string; syntax?: string; description?: string }[]
   >;
   cssAtom: Atom<string>;
-  sectionReadAtom: Atom<(section: SectionKey, property?: string) => string>;
-  sectionReadDimensionAtom: Atom<
-    (section: SectionKey, property: string) => CssDimension | null
+  sectionReadAtom: Atom<
+    (section: SectionKey, options?: ReadSectionOptions) => string
   >;
   sectionReadShorthandDimensionAtom: Atom<
     (section: SectionKey, property: string) => ShorthandDimensions
   >;
   sectionWriteAtom: WritableAtom<
     null,
-    [{ section: SectionKey; declarations: string }],
+    [{ section: SectionKey; declarations: string; preserve?: RegExp[] }],
     void
   >;
   sectionPropertyWriteAtom: WritableAtom<
@@ -107,16 +105,13 @@ export const StyleMolecule = molecule(
      */
     const sectionReadAtom = atom(get => {
       const css = get(cssAtom);
-      return (section: SectionKey, property?: string, exclude?: RegExp[]) =>
-        readSection(css, section, property, exclude);
+      return (section: SectionKey, options?: ReadSectionOptions) =>
+        readSection(css, section, options);
     });
 
-    const sectionReadDimensionAtom = atom(get => {
-      const css = get(cssAtom);
-      return (section: SectionKey, property: string) =>
-        readSectionDimension(css, section, property);
-    });
-
+    /**
+     * Returns the values of the `top`/`right`/`bottom`/`left` dimensions for a single section and property, if that property is a valid CSS shorthand for 1-4 directional values. Otherwise returns null for all directions.
+     */
     const sectionReadShorthandDimensionAtom = atom(get => {
       const css = get(cssAtom);
       return (section: SectionKey, property: string) =>
@@ -132,16 +127,23 @@ export const StyleMolecule = molecule(
       (
         get,
         set,
-        { section, declarations }: { section: SectionKey; declarations: string }
+        {
+          section,
+          declarations,
+          preserve,
+        }: { section: SectionKey; declarations: string; preserve?: RegExp[] }
       ) => {
         const node = get(selectedElementAtom);
         if (!node) return;
         const prev = get(GetInstanceCssAtom)(node);
-        const next = writeSection(prev, section, declarations);
+        const next = writeSection(prev, section, declarations, preserve);
         set(SetInstanceCssAtom, { node, css: next });
       }
     );
 
+    /**
+     * Writes a single property within a section, other properties in that section and other sections in the per-instance CSS are preserved untouched.
+     */
     const sectionPropertyWriteAtom = atom(
       null,
       (
@@ -168,7 +170,6 @@ export const StyleMolecule = molecule(
       customPropsAtom,
       cssAtom,
       sectionReadAtom,
-      sectionReadDimensionAtom,
       sectionReadShorthandDimensionAtom,
       sectionWriteAtom,
       sectionPropertyWriteAtom,

--- a/packages/react/src/css-editing/StyleMolecule.tsx
+++ b/packages/react/src/css-editing/StyleMolecule.tsx
@@ -1,7 +1,7 @@
 import { RaisinElementNode } from '@raisins/core';
 import { CssPart, CustomElement } from '@raisins/schema/schema';
 import { molecule, useMolecule } from 'bunshi/react';
-import { atom, useAtom, useAtomValue } from 'jotai';
+import { atom, useAtom, useAtomValue, Atom, WritableAtom } from 'jotai';
 import React, { useEffect, useState } from 'react';
 import { ComponentModelMolecule } from '../component-metamodel';
 import { SelectedNodeMolecule } from '../core/selection/SelectedNodeMolecule';
@@ -12,7 +12,29 @@ import {
   SectionKey,
   selectorOf,
   writeSection,
+  writeSectionProperty,
 } from './cssSections';
+
+export type StyleMoleculeType = {
+  selectedElementAtom: Atom<RaisinElementNode | undefined>;
+  componentMetaAtom: Atom<CustomElement | undefined>;
+  partsAtom: Atom<CssPart[]>;
+  customPropsAtom: Atom<
+    { name: string; syntax?: string; description?: string }[]
+  >;
+  cssAtom: Atom<string>;
+  sectionReadAtom: Atom<(section: SectionKey) => string>;
+  sectionWriteAtom: WritableAtom<
+    null,
+    [{ section: SectionKey; declarations: string }],
+    void
+  >;
+  sectionPropertyWriteAtom: WritableAtom<
+    null,
+    [{ section: SectionKey; property: string; value: string }],
+    void
+  >;
+};
 
 /**
  * Per-instance CSS editor for the currently selected element. Exposes:
@@ -27,84 +49,108 @@ import {
  * molecule deliberately stops at the source-of-truth string so widgets can
  * be composed freely.
  */
-export const StyleMolecule = molecule(getMol => {
-  const { SelectedNodeAtom } = getMol(SelectedNodeMolecule);
-  const { ComponentMetaAtom } = getMol(ComponentModelMolecule);
-  const {
-    GetInstanceCssAtom,
-    SetInstanceCssAtom,
-  } = getMol(CssEditingMolecule);
+export const StyleMolecule = molecule(
+  (getMol): StyleMoleculeType => {
+    const { SelectedNodeAtom } = getMol(SelectedNodeMolecule);
+    const { ComponentMetaAtom } = getMol(ComponentModelMolecule);
+    const { GetInstanceCssAtom, SetInstanceCssAtom } = getMol(
+      CssEditingMolecule
+    );
 
-  const selectedElementAtom = atom(get => {
-    const node = get(SelectedNodeAtom);
-    if (!node || !isElementNode(node)) return undefined;
-    return node;
-  });
+    const selectedElementAtom = atom(get => {
+      const node = get(SelectedNodeAtom);
+      if (!node || !isElementNode(node)) return undefined;
+      return node;
+    });
 
-  const componentMetaAtom = atom(get => {
-    const node = get(selectedElementAtom);
-    if (!node) return undefined;
-    return get(ComponentMetaAtom)(node.tagName) as CustomElement;
-  });
-
-  const partsAtom = atom<CssPart[]>(
-    get => get(componentMetaAtom)?.cssParts ?? []
-  );
-
-  const customPropsAtom = atom(get => get(componentMetaAtom)?.cssProperties ?? []);
-
-  const cssAtom = atom(
-    get => {
+    const componentMetaAtom = atom(get => {
       const node = get(selectedElementAtom);
-      if (!node) return '';
-      return get(GetInstanceCssAtom)(node);
-    },
-    (get, set, next: string) => {
-      const node = get(selectedElementAtom);
-      if (!node) return;
-      set(SetInstanceCssAtom, { node, css: next });
-    }
-  );
+      if (!node) return undefined;
+      return get(ComponentMetaAtom)(node.tagName) as CustomElement;
+    });
 
-  /**
-   * Returns the declarations text for a specific editable section
-   * (e.g. `:host` or `::part(header)`) of the currently selected element's
-   * per-instance CSS.
-   */
-  const sectionReadAtom = atom(get => {
-    const css = get(cssAtom);
-    return (section: SectionKey) => readSection(css, section);
-  });
+    const partsAtom = atom<CssPart[]>(
+      get => get(componentMetaAtom)?.cssParts ?? []
+    );
 
-  /**
-   * Writes new declarations for a single section. Other sections (and any
-   * unrecognised rules) in the per-instance CSS are preserved untouched.
-   */
-  const sectionWriteAtom = atom(
-    null,
-    (
-      get,
-      set,
-      { section, declarations }: { section: SectionKey; declarations: string }
-    ) => {
-      const node = get(selectedElementAtom);
-      if (!node) return;
-      const prev = get(GetInstanceCssAtom)(node);
-      const next = writeSection(prev, section, declarations);
-      set(SetInstanceCssAtom, { node, css: next });
-    }
-  );
+    const customPropsAtom = atom(
+      get => get(componentMetaAtom)?.cssProperties ?? []
+    );
 
-  return {
-    selectedElementAtom,
-    componentMetaAtom,
-    partsAtom,
-    customPropsAtom,
-    cssAtom,
-    sectionReadAtom,
-    sectionWriteAtom,
-  };
-});
+    const cssAtom = atom(
+      get => {
+        const node = get(selectedElementAtom);
+        if (!node) return '';
+        return get(GetInstanceCssAtom)(node);
+      },
+      (get, set, next: string) => {
+        const node = get(selectedElementAtom);
+        if (!node) return;
+        set(SetInstanceCssAtom, { node, css: next });
+      }
+    );
+
+    /**
+     * Returns the declarations text for a specific editable section
+     * (e.g. `:host` or `::part(header)`) of the currently selected element's
+     * per-instance CSS.
+     */
+    const sectionReadAtom = atom(get => {
+      const css = get(cssAtom);
+      return (section: SectionKey, property?: string) =>
+        readSection(css, section, property);
+    });
+
+    /**
+     * Writes new declarations for a single section. Other sections (and any
+     * unrecognised rules) in the per-instance CSS are preserved untouched.
+     */
+    const sectionWriteAtom = atom(
+      null,
+      (
+        get,
+        set,
+        { section, declarations }: { section: SectionKey; declarations: string }
+      ) => {
+        const node = get(selectedElementAtom);
+        if (!node) return;
+        const prev = get(GetInstanceCssAtom)(node);
+        const next = writeSection(prev, section, declarations);
+        set(SetInstanceCssAtom, { node, css: next });
+      }
+    );
+
+    const sectionPropertyWriteAtom = atom(
+      null,
+      (
+        get,
+        set,
+        {
+          section,
+          property,
+          value,
+        }: { section: SectionKey; property: string; value: string }
+      ) => {
+        const node = get(selectedElementAtom);
+        if (!node) return;
+        const prev = get(GetInstanceCssAtom)(node);
+        const next = writeSectionProperty(prev, section, property, value);
+        set(SetInstanceCssAtom, { node, css: next });
+      }
+    );
+
+    return {
+      selectedElementAtom,
+      componentMetaAtom,
+      partsAtom,
+      customPropsAtom,
+      cssAtom,
+      sectionReadAtom,
+      sectionWriteAtom,
+      sectionPropertyWriteAtom,
+    };
+  }
+);
 
 /**
  * Per-instance CSS editor. Renders one editable section for the element
@@ -137,7 +183,9 @@ export const StylePanel: React.FC = () => {
       <h3>Style: {selected.tagName}</h3>
 
       <SectionEditor
-        key={`element-${selected.tagName}-${selected.attribs['data-raisin-id'] ?? ''}`}
+        key={`element-${selected.tagName}-${selected.attribs[
+          'data-raisin-id'
+        ] ?? ''}`}
         section={{ type: 'element' }}
         title="Element"
         description={`Applies to the component itself (rendered as :host).`}

--- a/packages/react/src/css-editing/StyleMolecule.tsx
+++ b/packages/react/src/css-editing/StyleMolecule.tsx
@@ -8,9 +8,13 @@ import { SelectedNodeMolecule } from '../core/selection/SelectedNodeMolecule';
 import { isElementNode } from '../util/isNode';
 import { CssEditingMolecule } from './CssEditingMolecule';
 import {
+  CssDimension,
   readSection,
+  readSectionDimension,
+  readSectionShorthandDimension,
   SectionKey,
   selectorOf,
+  ShorthandDimensions,
   writeSection,
   writeSectionProperty,
 } from './cssSections';
@@ -23,7 +27,13 @@ export type StyleMoleculeType = {
     { name: string; syntax?: string; description?: string }[]
   >;
   cssAtom: Atom<string>;
-  sectionReadAtom: Atom<(section: SectionKey) => string>;
+  sectionReadAtom: Atom<(section: SectionKey, property?: string) => string>;
+  sectionReadDimensionAtom: Atom<
+    (section: SectionKey, property: string) => CssDimension | null
+  >;
+  sectionReadShorthandDimensionAtom: Atom<
+    (section: SectionKey, property: string) => ShorthandDimensions
+  >;
   sectionWriteAtom: WritableAtom<
     null,
     [{ section: SectionKey; declarations: string }],
@@ -97,8 +107,20 @@ export const StyleMolecule = molecule(
      */
     const sectionReadAtom = atom(get => {
       const css = get(cssAtom);
-      return (section: SectionKey, property?: string) =>
-        readSection(css, section, property);
+      return (section: SectionKey, property?: string, exclude?: RegExp[]) =>
+        readSection(css, section, property, exclude);
+    });
+
+    const sectionReadDimensionAtom = atom(get => {
+      const css = get(cssAtom);
+      return (section: SectionKey, property: string) =>
+        readSectionDimension(css, section, property);
+    });
+
+    const sectionReadShorthandDimensionAtom = atom(get => {
+      const css = get(cssAtom);
+      return (section: SectionKey, property: string) =>
+        readSectionShorthandDimension(css, section, property);
     });
 
     /**
@@ -146,6 +168,8 @@ export const StyleMolecule = molecule(
       customPropsAtom,
       cssAtom,
       sectionReadAtom,
+      sectionReadDimensionAtom,
+      sectionReadShorthandDimensionAtom,
       sectionWriteAtom,
       sectionPropertyWriteAtom,
     };

--- a/packages/react/src/css-editing/StyleMolecule.tsx
+++ b/packages/react/src/css-editing/StyleMolecule.tsx
@@ -42,6 +42,7 @@ export type StyleMoleculeType = {
     [{ section: SectionKey; property: string; value: string }],
     void
   >;
+  conflictsAtom: Atom<boolean>;
 };
 
 /**
@@ -118,6 +119,8 @@ export const StyleMolecule = molecule(
         readSectionShorthandDimension(css, section, property);
     });
 
+    const conflictsAtom = atom(false);
+
     /**
      * Writes new declarations for a single section. Other sections (and any
      * unrecognised rules) in the per-instance CSS are preserved untouched.
@@ -136,8 +139,9 @@ export const StyleMolecule = molecule(
         const node = get(selectedElementAtom);
         if (!node) return;
         const prev = get(GetInstanceCssAtom)(node);
-        const next = writeSection(prev, section, declarations, preserve);
-        set(SetInstanceCssAtom, { node, css: next });
+        const {css, conflict} = writeSection(prev, section, declarations, preserve);
+        set(conflictsAtom, conflict);
+        set(SetInstanceCssAtom, { node, css });
       }
     );
 
@@ -173,6 +177,7 @@ export const StyleMolecule = molecule(
       sectionReadShorthandDimensionAtom,
       sectionWriteAtom,
       sectionPropertyWriteAtom,
+      conflictsAtom,
     };
   }
 );

--- a/packages/react/src/css-editing/cssSections.ts
+++ b/packages/react/src/css-editing/cssSections.ts
@@ -26,6 +26,11 @@ export type ShorthandDimensions = {
   left: CssDimension | null;
 };
 
+export type ReadSectionOptions = {
+  property?: string;
+  exclude?: RegExp[];
+};
+
 /**
  * Reads the declarations of the rule that matches `section` if a property is not specified, formatted as a
  * CSS declaration block string (e.g. `color: red;\npadding: 10px`). If a property is specified, returns the value of that property.
@@ -34,9 +39,9 @@ export type ShorthandDimensions = {
 export function readSection(
   css: string,
   section: SectionKey,
-  property?: string,
-  exclude?: RegExp[]
+  options?: ReadSectionOptions
 ): string {
+  const { property, exclude } = options ?? {};
   if (!css.trim()) return '';
   let ast: any;
   try {
@@ -51,35 +56,6 @@ export function readSection(
     return decl && decl.value ? cssSerializer(decl.value) : '';
   }
   return serializeDeclarations(rule.block, exclude);
-}
-
-export function readSectionDimension(
-  css: string,
-  section: SectionKey,
-  property: string
-): CssDimension | null {
-  if (!css.trim()) return null;
-  let ast: any;
-  try {
-    ast = cssParser(css);
-  } catch {
-    return null;
-  }
-  const rule = findMatchingRule(ast, section);
-  if (!rule) return null;
-  const decl = findDeclaration(rule, property);
-  if (decl && decl.value?.children?.at(0)?.type === 'Dimension') {
-    return {
-      value: decl.value.children[0].value,
-      unit: decl.value.children[0].unit,
-    };
-  } else if (decl && decl.value?.children?.at(0)?.type === 'Percentage') {
-    return {
-      value: decl.value.children[0].value,
-      unit: '%',
-    };
-  }
-  return null;
 }
 
 export function readSectionShorthandDimension(
@@ -153,11 +129,18 @@ function nodeToDimension(node: any): CssDimension | null {
  * `section` replaced by `declarations`. If no matching rule exists, appends
  * a new rule. If `declarations` is empty / whitespace, removes the matching
  * rule entirely. Other rules are preserved unchanged.
+ *
+ * When `preserve` is provided, any existing declarations whose property name
+ * matches one of the patterns are kept in the block even if they are absent
+ * from the incoming `declarations`. This lets a partial editor (e.g. an
+ * "advanced CSS" textarea that deliberately hides managed properties) write
+ * freely without accidentally wiping those managed values.
  */
 export function writeSection(
   css: string,
   section: SectionKey,
-  declarations: string
+  declarations: string,
+  preserve: RegExp[] = []
 ): string {
   const trimmed = declarations.trim();
   let ast: any;
@@ -172,13 +155,39 @@ export function writeSection(
     (rule: any) => rule.type === 'Rule' && ruleMatches(rule, section)
   );
 
-  if (trimmed.length === 0) {
+  if (trimmed.length === 0 && preserve.length === 0) {
     if (existingIdx >= 0) ast.children.splice(existingIdx, 1);
     return cssSerializer(ast);
   }
 
-  const newBlock = parseDeclarationBlock(trimmed);
+  const newBlock = trimmed.length > 0 ? parseDeclarationBlock(trimmed) : { type: 'Block', children: [] as any[] };
   if (!newBlock) return css;
+
+  if (preserve.length > 0 && existingIdx >= 0) {
+    const existingBlock = ast.children[existingIdx].block;
+    if (existingBlock && Array.isArray(existingBlock.children)) {
+      const preservedDecls = existingBlock.children.filter(
+        (d: any) =>
+          d.type === 'Declaration' &&
+          typeof d.property === 'string' &&
+          preserve.some(regex => regex.test(d.property))
+      );
+      const newPropSet = new Set(
+        newBlock.children
+          .filter((d: any) => d.type === 'Declaration')
+          .map((d: any) => d.property as string)
+      );
+      const toKeep = preservedDecls.filter(
+        (d: any) => !newPropSet.has(d.property)
+      );
+      newBlock.children = [...toKeep, ...newBlock.children];
+    }
+  }
+
+  if (newBlock.children.length === 0 && trimmed.length === 0) {
+    if (existingIdx >= 0) ast.children.splice(existingIdx, 1);
+    return cssSerializer(ast);
+  }
 
   if (existingIdx >= 0) {
     ast.children[existingIdx] = {
@@ -226,7 +235,6 @@ export function writeSectionProperty(
   }
 
   const newDeclarations = serializeDeclarations(block);
-  console.log('New declarations:', newDeclarations);
   return writeSection(css, section, newDeclarations);
 }
 

--- a/packages/react/src/css-editing/cssSections.ts
+++ b/packages/react/src/css-editing/cssSections.ts
@@ -10,9 +10,7 @@ import { cssParser, cssSerializer } from '@raisins/core';
  * Other rules in the CSS (e.g. raw selectors, at-rules) are left untouched by
  * {@link writeSection} — only the matching rule, if any, is rewritten.
  */
-export type SectionKey =
-  | { type: 'element' }
-  | { type: 'part'; name: string };
+export type SectionKey = { type: 'element' } | { type: 'part'; name: string };
 
 export function selectorOf(section: SectionKey): string {
   if (section.type === 'element') return ':host';
@@ -20,11 +18,15 @@ export function selectorOf(section: SectionKey): string {
 }
 
 /**
- * Reads the declarations of the rule that matches `section`, formatted as a
- * CSS declaration block string (e.g. `color: red;\npadding: 10px`). Returns
- * "" if no matching rule exists.
+ * Reads the declarations of the rule that matches `section` if a property is not specified, formatted as a
+ * CSS declaration block string (e.g. `color: red;\npadding: 10px`). If a property is specified, returns the value of that property.
+ * Returns "" if no matching rule or property exists.
  */
-export function readSection(css: string, section: SectionKey): string {
+export function readSection(
+  css: string,
+  section: SectionKey,
+  property?: string
+): string {
   if (!css.trim()) return '';
   let ast: any;
   try {
@@ -34,6 +36,12 @@ export function readSection(css: string, section: SectionKey): string {
   }
   const rule = findMatchingRule(ast, section);
   if (!rule) return '';
+  if (property) {
+    const decl = rule.block.children.find(
+      (d: any) => d.type === 'Declaration' && d.property === property
+    );
+    return decl && decl.value ? cssSerializer(decl.value) : '';
+  }
   return serializeDeclarations(rule.block);
 }
 
@@ -80,6 +88,44 @@ export function writeSection(
   return cssSerializer(ast);
 }
 
+export function writeSectionProperty(
+  css: string,
+  section: SectionKey,
+  property: string,
+  value: string
+): string {
+  const current = readSection(css, section);
+
+  // Parse existing declarations into a block AST
+  let block: any = current.trim()
+    ? parseDeclarationBlock(current)
+    : parseDeclarationBlock('');
+  if (!block) block = { type: 'Block', children: [] };
+
+  const declIdx = block.children.findIndex(
+    (d: any) => d.type === 'Declaration' && d.property === property
+  );
+
+  if (value.trim().length === 0) {
+    // Remove property
+    if (declIdx >= 0) block.children.splice(declIdx, 1);
+  } else {
+    // Parse a fresh declaration to get a proper AST node with correct .value
+    const freshBlock = parseDeclarationBlock(`${property}: ${value}`);
+    const freshDecl = freshBlock?.children?.[0];
+    if (!freshDecl) return css;
+
+    if (declIdx >= 0) {
+      block.children[declIdx] = freshDecl;
+    } else {
+      block.children.push(freshDecl);
+    }
+  }
+
+  const newDeclarations = serializeDeclarations(block);
+  return writeSection(css, section, newDeclarations);
+}
+
 function findMatchingRule(ast: any, section: SectionKey): any | undefined {
   if (!Array.isArray(ast.children)) return undefined;
   return ast.children.find(
@@ -122,7 +168,10 @@ function serializeDeclarations(block: any): string {
     .map((decl: any) => {
       const fauxBlock = { ...block, children: [decl] };
       const inner = cssSerializer(fauxBlock);
-      return inner.replace(/^\{/, '').replace(/\}$/, '').trim();
+      return inner
+        .replace(/^\{/, '')
+        .replace(/\}$/, '')
+        .trim();
     })
     .filter((line: string) => line.length > 0)
     .join(';\n');

--- a/packages/react/src/css-editing/cssSections.ts
+++ b/packages/react/src/css-editing/cssSections.ts
@@ -17,6 +17,15 @@ export function selectorOf(section: SectionKey): string {
   return `::part(${section.name})`;
 }
 
+export type CssDimension = { value: string; unit: string };
+
+export type ShorthandDimensions = {
+  top: CssDimension | null;
+  right: CssDimension | null;
+  bottom: CssDimension | null;
+  left: CssDimension | null;
+};
+
 /**
  * Reads the declarations of the rule that matches `section` if a property is not specified, formatted as a
  * CSS declaration block string (e.g. `color: red;\npadding: 10px`). If a property is specified, returns the value of that property.
@@ -25,7 +34,8 @@ export function selectorOf(section: SectionKey): string {
 export function readSection(
   css: string,
   section: SectionKey,
-  property?: string
+  property?: string,
+  exclude?: RegExp[]
 ): string {
   if (!css.trim()) return '';
   let ast: any;
@@ -37,12 +47,105 @@ export function readSection(
   const rule = findMatchingRule(ast, section);
   if (!rule) return '';
   if (property) {
-    const decl = rule.block.children.find(
-      (d: any) => d.type === 'Declaration' && d.property === property
-    );
+    const decl = findDeclaration(rule, property);
     return decl && decl.value ? cssSerializer(decl.value) : '';
   }
-  return serializeDeclarations(rule.block);
+  return serializeDeclarations(rule.block, exclude);
+}
+
+export function readSectionDimension(
+  css: string,
+  section: SectionKey,
+  property: string
+): CssDimension | null {
+  if (!css.trim()) return null;
+  let ast: any;
+  try {
+    ast = cssParser(css);
+  } catch {
+    return null;
+  }
+  const rule = findMatchingRule(ast, section);
+  if (!rule) return null;
+  const decl = findDeclaration(rule, property);
+  if (decl && decl.value?.children?.at(0)?.type === 'Dimension') {
+    return {
+      value: decl.value.children[0].value,
+      unit: decl.value.children[0].unit,
+    };
+  } else if (decl && decl.value?.children?.at(0)?.type === 'Percentage') {
+    return {
+      value: decl.value.children[0].value,
+      unit: '%',
+    };
+  }
+  return null;
+}
+
+export function readSectionShorthandDimension(
+  css: string,
+  section: SectionKey,
+  property: string
+): ShorthandDimensions {
+  const nil: ShorthandDimensions = {
+    top: null,
+    right: null,
+    bottom: null,
+    left: null,
+  };
+  if (!css.trim()) return nil;
+  let ast: any;
+  try {
+    ast = cssParser(css);
+  } catch {
+    return nil;
+  }
+  const rule = findMatchingRule(ast, section);
+  if (!rule) return nil;
+
+  const shorthandDecl = findDeclaration(rule, property);
+  const result = { ...nil };
+
+  if (shorthandDecl) {
+    const values = (shorthandDecl.value?.children ?? []).filter(
+      (n: any) => n.type !== 'WhiteSpace'
+    );
+    const dims = values.map(nodeToDimension);
+
+    if (dims.length === 1) {
+      result.top = result.right = result.bottom = result.left = dims[0];
+    } else if (dims.length === 2) {
+      result.top = result.bottom = dims[0];
+      result.right = result.left = dims[1];
+    } else if (dims.length === 3) {
+      result.top = dims[0];
+      result.right = result.left = dims[1];
+      result.bottom = dims[2];
+    } else if (dims.length >= 4) {
+      result.top = dims[0];
+      result.right = dims[1];
+      result.bottom = dims[2];
+      result.left = dims[3];
+    }
+  }
+
+  const sides = ['top', 'right', 'bottom', 'left'] as const;
+  for (const side of sides) {
+    const longhand = findDeclaration(rule, `${property}-${side}`);
+    if (longhand) {
+      const val = nodeToDimension(longhand.value?.children?.[0]);
+      if (val) result[side] = val;
+    }
+  }
+
+  return result;
+}
+
+function nodeToDimension(node: any): CssDimension | null {
+  if (!node) return null;
+  if (node.type === 'Dimension') return { value: node.value, unit: node.unit };
+  if (node.type === 'Percentage') return { value: node.value, unit: '%' };
+  return null;
 }
 
 /**
@@ -123,6 +226,7 @@ export function writeSectionProperty(
   }
 
   const newDeclarations = serializeDeclarations(block);
+  console.log('New declarations:', newDeclarations);
   return writeSection(css, section, newDeclarations);
 }
 
@@ -130,6 +234,12 @@ function findMatchingRule(ast: any, section: SectionKey): any | undefined {
   if (!Array.isArray(ast.children)) return undefined;
   return ast.children.find(
     (rule: any) => rule.type === 'Rule' && ruleMatches(rule, section)
+  );
+}
+
+function findDeclaration(rule: any, property: string): any | undefined {
+  return rule.block.children.find(
+    (d: any) => d.type === 'Declaration' && d.property === property
   );
 }
 
@@ -162,10 +272,11 @@ function selectorMatches(selector: any, section: SectionKey): boolean {
   return only.children[0]?.value === section.name;
 }
 
-function serializeDeclarations(block: any): string {
+function serializeDeclarations(block: any, exclude: RegExp[] = []): string {
   if (!block || !Array.isArray(block.children)) return '';
   return block.children
     .map((decl: any) => {
+      if (exclude.some(regex => regex.test(decl.property))) return '';
       const fauxBlock = { ...block, children: [decl] };
       const inner = cssSerializer(fauxBlock);
       return inner

--- a/packages/react/src/css-editing/cssSections.ts
+++ b/packages/react/src/css-editing/cssSections.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { cssParser, cssSerializer } from '@raisins/core';
+
+/**
+ * A logical editable section of the per-instance CSS for a single element.
+ *
+ * - `element`  → the rule whose selector is `:host`
+ * - `part(<n>)` → the rule whose selector is `::part(<n>)`
+ *
+ * Other rules in the CSS (e.g. raw selectors, at-rules) are left untouched by
+ * {@link writeSection} — only the matching rule, if any, is rewritten.
+ */
+export type SectionKey =
+  | { type: 'element' }
+  | { type: 'part'; name: string };
+
+export function selectorOf(section: SectionKey): string {
+  if (section.type === 'element') return ':host';
+  return `::part(${section.name})`;
+}
+
+/**
+ * Reads the declarations of the rule that matches `section`, formatted as a
+ * CSS declaration block string (e.g. `color: red;\npadding: 10px`). Returns
+ * "" if no matching rule exists.
+ */
+export function readSection(css: string, section: SectionKey): string {
+  if (!css.trim()) return '';
+  let ast: any;
+  try {
+    ast = cssParser(css);
+  } catch {
+    return '';
+  }
+  const rule = findMatchingRule(ast, section);
+  if (!rule) return '';
+  return serializeDeclarations(rule.block);
+}
+
+/**
+ * Returns a new CSS string with the declarations of the rule matching
+ * `section` replaced by `declarations`. If no matching rule exists, appends
+ * a new rule. If `declarations` is empty / whitespace, removes the matching
+ * rule entirely. Other rules are preserved unchanged.
+ */
+export function writeSection(
+  css: string,
+  section: SectionKey,
+  declarations: string
+): string {
+  const trimmed = declarations.trim();
+  let ast: any;
+  try {
+    ast = css.trim() ? cssParser(css) : cssParser('');
+  } catch {
+    ast = cssParser('');
+  }
+  if (!Array.isArray(ast.children)) ast.children = [];
+
+  const existingIdx = ast.children.findIndex(
+    (rule: any) => rule.type === 'Rule' && ruleMatches(rule, section)
+  );
+
+  if (trimmed.length === 0) {
+    if (existingIdx >= 0) ast.children.splice(existingIdx, 1);
+    return cssSerializer(ast);
+  }
+
+  const newBlock = parseDeclarationBlock(trimmed);
+  if (!newBlock) return css;
+
+  if (existingIdx >= 0) {
+    ast.children[existingIdx] = {
+      ...ast.children[existingIdx],
+      block: newBlock,
+    };
+  } else {
+    ast.children.push(buildRule(section, newBlock));
+  }
+  return cssSerializer(ast);
+}
+
+function findMatchingRule(ast: any, section: SectionKey): any | undefined {
+  if (!Array.isArray(ast.children)) return undefined;
+  return ast.children.find(
+    (rule: any) => rule.type === 'Rule' && ruleMatches(rule, section)
+  );
+}
+
+function ruleMatches(rule: any, section: SectionKey): boolean {
+  const selectors = rule.prelude?.children;
+  if (!Array.isArray(selectors)) return false;
+  return selectors.some((sel: any) => selectorMatches(sel, section));
+}
+
+function selectorMatches(selector: any, section: SectionKey): boolean {
+  if (selector.type !== 'Selector' || !Array.isArray(selector.children)) {
+    return false;
+  }
+  if (selector.children.length !== 1) return false;
+  const only = selector.children[0];
+  if (section.type === 'element') {
+    return (
+      only.type === 'PseudoClassSelector' &&
+      only.name === 'host' &&
+      !only.children
+    );
+  }
+  if (
+    only.type !== 'PseudoElementSelector' ||
+    only.name !== 'part' ||
+    !Array.isArray(only.children)
+  ) {
+    return false;
+  }
+  return only.children[0]?.value === section.name;
+}
+
+function serializeDeclarations(block: any): string {
+  if (!block || !Array.isArray(block.children)) return '';
+  return block.children
+    .map((decl: any) => {
+      const fauxBlock = { ...block, children: [decl] };
+      const inner = cssSerializer(fauxBlock);
+      return inner.replace(/^\{/, '').replace(/\}$/, '').trim();
+    })
+    .filter((line: string) => line.length > 0)
+    .join(';\n');
+}
+
+function parseDeclarationBlock(declarations: string): any | undefined {
+  const normalized = declarations.replace(/;\s*$/, '');
+  const wrapped = `*{${normalized}}`;
+  let ast: any;
+  try {
+    ast = cssParser(wrapped);
+  } catch {
+    return undefined;
+  }
+  const rule = ast.children?.[0];
+  if (!rule || rule.type !== 'Rule' || !rule.block) return undefined;
+  return rule.block;
+}
+
+function buildRule(section: SectionKey, block: any): any {
+  const ast: any = cssParser(`${selectorOf(section)}{}`);
+  const rule = ast.children[0];
+  rule.block = block;
+  return rule;
+}

--- a/packages/react/src/css-editing/cssSections.ts
+++ b/packages/react/src/css-editing/cssSections.ts
@@ -141,7 +141,7 @@ export function writeSection(
   section: SectionKey,
   declarations: string,
   preserve: RegExp[] = []
-): string {
+): { css: string; conflict: boolean } {
   const trimmed = declarations.trim();
   let ast: any;
   try {
@@ -157,11 +157,16 @@ export function writeSection(
 
   if (trimmed.length === 0 && preserve.length === 0) {
     if (existingIdx >= 0) ast.children.splice(existingIdx, 1);
-    return cssSerializer(ast);
+    return { css: cssSerializer(ast), conflict: false };
   }
 
-  const newBlock = trimmed.length > 0 ? parseDeclarationBlock(trimmed) : { type: 'Block', children: [] as any[] };
-  if (!newBlock) return css;
+  const newBlock =
+    trimmed.length > 0
+      ? parseDeclarationBlock(trimmed)
+      : { type: 'Block', children: [] as any[] };
+  if (!newBlock) return { css, conflict: false };
+
+  const conflict = identifyAndFilterConflicts(newBlock, preserve);
 
   if (preserve.length > 0 && existingIdx >= 0) {
     const existingBlock = ast.children[existingIdx].block;
@@ -172,21 +177,13 @@ export function writeSection(
           typeof d.property === 'string' &&
           preserve.some(regex => regex.test(d.property))
       );
-      const newPropSet = new Set(
-        newBlock.children
-          .filter((d: any) => d.type === 'Declaration')
-          .map((d: any) => d.property as string)
-      );
-      const toKeep = preservedDecls.filter(
-        (d: any) => !newPropSet.has(d.property)
-      );
-      newBlock.children = [...toKeep, ...newBlock.children];
+      newBlock.children = [...preservedDecls, ...newBlock.children];
     }
   }
 
   if (newBlock.children.length === 0 && trimmed.length === 0) {
     if (existingIdx >= 0) ast.children.splice(existingIdx, 1);
-    return cssSerializer(ast);
+    return { css: cssSerializer(ast), conflict };
   }
 
   if (existingIdx >= 0) {
@@ -197,7 +194,28 @@ export function writeSection(
   } else {
     ast.children.push(buildRule(section, newBlock));
   }
-  return cssSerializer(ast);
+  return { css: cssSerializer(ast), conflict };
+}
+
+function identifyAndFilterConflicts(block: any, preserve: RegExp[]): boolean {
+  if (!block || !Array.isArray(block.children)) return false;
+  let conflict = false;
+  const filteredBlock = block.children.filter((d: any) => {
+    if (
+      !(
+        d.type === 'Declaration' &&
+        typeof d.property === 'string' &&
+        preserve.some(regex => regex.test(d.property))
+      )
+    ) {
+      return true;
+    } else {
+      conflict = true;
+      return false;
+    }
+  });
+  block.children = filteredBlock;
+  return conflict;
 }
 
 export function writeSectionProperty(
@@ -235,7 +253,7 @@ export function writeSectionProperty(
   }
 
   const newDeclarations = serializeDeclarations(block);
-  return writeSection(css, section, newDeclarations);
+  return writeSection(css, section, newDeclarations).css;
 }
 
 function findMatchingRule(ast: any, section: SectionKey): any | undefined {

--- a/packages/react/src/css-editing/index.ts
+++ b/packages/react/src/css-editing/index.ts
@@ -1,0 +1,8 @@
+export {
+  CssEditingMolecule,
+  RAISIN_CSS_ATTR,
+  RAISIN_ID_ATTR,
+} from './CssEditingMolecule';
+export type { CssEditingMoleculeType } from './CssEditingMolecule';
+export { StyleMolecule, StylePanel } from './StyleMolecule';
+export { DocumentCssMolecule, DocumentCssEditor } from './DocumentCssMolecule';

--- a/packages/react/src/css-editing/index.ts
+++ b/packages/react/src/css-editing/index.ts
@@ -5,6 +5,7 @@ export {
 } from './CssEditingMolecule';
 export type { CssEditingMoleculeType } from './CssEditingMolecule';
 export type { StyleMoleculeType } from './StyleMolecule';
-export type { SectionKey } from './cssSections';
+export type { SectionKey, CssDimension, ShorthandDimensions } from './cssSections';
+export { readSectionDimension, readSectionShorthandDimension } from './cssSections';
 export { StyleMolecule, StylePanel } from './StyleMolecule';
 export { DocumentCssMolecule, DocumentCssEditor } from './DocumentCssMolecule';

--- a/packages/react/src/css-editing/index.ts
+++ b/packages/react/src/css-editing/index.ts
@@ -5,7 +5,7 @@ export {
 } from './CssEditingMolecule';
 export type { CssEditingMoleculeType } from './CssEditingMolecule';
 export type { StyleMoleculeType } from './StyleMolecule';
-export type { SectionKey, CssDimension, ShorthandDimensions } from './cssSections';
-export { readSectionDimension, readSectionShorthandDimension } from './cssSections';
+export type { SectionKey, CssDimension, ShorthandDimensions, ReadSectionOptions } from './cssSections';
+export { readSectionShorthandDimension } from './cssSections';
 export { StyleMolecule, StylePanel } from './StyleMolecule';
 export { DocumentCssMolecule, DocumentCssEditor } from './DocumentCssMolecule';

--- a/packages/react/src/css-editing/index.ts
+++ b/packages/react/src/css-editing/index.ts
@@ -4,5 +4,7 @@ export {
   RAISIN_ID_ATTR,
 } from './CssEditingMolecule';
 export type { CssEditingMoleculeType } from './CssEditingMolecule';
+export type { StyleMoleculeType } from './StyleMolecule';
+export type { SectionKey } from './cssSections';
 export { StyleMolecule, StylePanel } from './StyleMolecule';
 export { DocumentCssMolecule, DocumentCssEditor } from './DocumentCssMolecule';

--- a/packages/react/src/index.stories.tsx
+++ b/packages/react/src/index.stories.tsx
@@ -25,6 +25,8 @@ import { CoreMolecule, SelectedNodeMolecule } from './core';
 import { HistoryMolecule } from './core/editting/HistoryAtoms';
 import { RaisinConfig, RaisinsProvider } from './core/RaisinConfigScope';
 import { HoveredNodeMolecule } from './core/selection/HoveredNodeMolecule';
+import { DocumentCssEditor } from './css-editing/DocumentCssMolecule';
+import { StylePanel } from './css-editing/StyleMolecule';
 import {
   big,
   LocalBedrockComponents,
@@ -278,6 +280,34 @@ export const TemplatesExample = () => (
   />
 );
 
+const kitchenSinkHtml = `
+<my-card label="Edit me">
+  <span slot="title">Hello world</span>
+  <p>This card exposes <code>::part(header)</code> and <code>::part(body)</code>. Click it, then edit the Style panel on the right.</p>
+</my-card>
+`;
+
+const CssEditingStoryMolecule = molecule<Partial<RaisinConfig>>(() => ({
+  HTMLAtom: atom(kitchenSinkHtml),
+  PackagesAtom: atom([{ package: '@local', version: 'next' }] as Module[]),
+  uiWidgetsAtom: atom({}),
+  LocalURLAtom: atom('http://localhost:5000'),
+}));
+
+/**
+ * Demonstrates the CSS editing surfaces against the kitchen-sink `<my-card>`
+ * component (annotated with `@csspart header` and `@csspart body`).
+ *
+ * Requires the kitchen-sink Stencil dev server to be running:
+ *   cd examples/my-kitchen-sink && npm run start:raisins
+ */
+export const CssEditing = () => (
+  <BasicStory
+    startingHtml={kitchenSinkHtml}
+    Molecule={CssEditingStoryMolecule}
+  />
+);
+
 const ToolbarMolecule = molecule(getMol => {
   return {
     ...getMol(HoveredNodeMolecule),
@@ -363,6 +393,10 @@ export function EditorView() {
 
         <div style={Edits}>
           <PackageEditor />
+          <hr />
+          <StylePanel />
+          <hr />
+          <DocumentCssEditor />
         </div>
       </div>
     </>

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -2,6 +2,7 @@ export * from './attributes';
 export * from './canvas';
 export * from './component-metamodel';
 export * from './core';
+export * from './css-editing';
 export * from './hotkeys';
 export * from './node';
 export * from './rich-text';

--- a/packages/react/src/node/slots/SlotChildrenController.stories.tsx
+++ b/packages/react/src/node/slots/SlotChildrenController.stories.tsx
@@ -1,8 +1,7 @@
 import { htmlUtil, RaisinDocumentNode, RaisinElementNode } from '@raisins/core';
 import { Meta } from '@storybook/react';
-import { atom, useAtom, useSetAtom } from 'jotai';
+import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { molecule, useMolecule } from 'bunshi/react';
-import { useAtomValue } from 'jotai/utils';
 import React, { CSSProperties, FC, useCallback, useState } from 'react';
 import { ComponentModelMolecule } from '../../component-metamodel/ComponentModel';
 import { CoreMolecule } from '../../core/CoreAtoms';

--- a/packages/schema/schema.d.ts
+++ b/packages/schema/schema.d.ts
@@ -85,6 +85,11 @@ export interface CustomElement {
   cssProperties?: CssCustomProperty[];
 
   /**
+   * The CSS shadow parts (`::part(name)`) this element exposes for external styling.
+   */
+  cssParts?: CssPart[];
+
+  /**
    * HTML examples of how this content can be used
    */
   examples?: Array<Example>;
@@ -300,6 +305,23 @@ export interface Slot {
    * rich text editing of children.
    */
   editor?: string;
+}
+
+export interface CssPart {
+  /**
+   * The name of the part, used in `::part(name)` selectors.
+   */
+  name: string;
+
+  /**
+   * A markdown title suitable for display in a listing.
+   */
+  title?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
 }
 
 export interface CssCustomProperty {

--- a/packages/stencil-docs-target/src/convertToRaisins.ts
+++ b/packages/stencil-docs-target/src/convertToRaisins.ts
@@ -92,11 +92,29 @@ export function convertToGrapesJSMeta(docs: JsonDocs): schema.Module {
             return attr;
           });
 
+        const cssParts: schema.CssPart[] | undefined = comp.parts?.length
+          ? comp.parts.map(p => ({
+              name: p.name,
+              description: p.docs || undefined,
+            }))
+          : undefined;
+
+        const cssProperties:
+          | schema.CssCustomProperty[]
+          | undefined = comp.styles?.length
+          ? comp.styles.map(s => ({
+              name: s.name,
+              description: s.docs || undefined,
+            }))
+          : undefined;
+
         const elem: schema.CustomElement = {
           tagName: comp.tag,
           title: uiName(comp) ?? comp.tag,
           slots: jsonTagValue(comp, 'slots') as schema.Slot[],
           attributes,
+          cssParts,
+          cssProperties,
           requiredFeatures: jsonTagValue(comp, 'requiredFeatures'),
           featureTooltip: tagValue(comp.docsTags, 'featureTooltip'),
           exampleGroup: tagValue(comp.docsTags, 'exampleGroup'),

--- a/packages/stencil-docs-target/src/convertToRaisins.ts
+++ b/packages/stencil-docs-target/src/convertToRaisins.ts
@@ -120,7 +120,7 @@ export function convertToGrapesJSMeta(docs: JsonDocs): schema.Module {
                   name: name.trim(),
                   description: description?.trim() || undefined,
                 };
-              }) || undefined;;
+              }) || undefined;
 
         const elem: schema.CustomElement = {
           tagName: comp.tag,

--- a/packages/stencil-docs-target/src/convertToRaisins.ts
+++ b/packages/stencil-docs-target/src/convertToRaisins.ts
@@ -92,21 +92,25 @@ export function convertToGrapesJSMeta(docs: JsonDocs): schema.Module {
             return attr;
           });
 
-        const cssParts: schema.CssPart[] | undefined = comp.parts?.length
-          ? comp.parts.map(p => ({
-              name: p.name,
-              description: p.docs || undefined,
-            }))
-          : undefined;
+        const cssParts: schema.CssPart[] | undefined = comp.docsTags
+              .filter(t => t.name === 'csspart')
+              .map(t => {
+                const [name, ...rest] = (t.text ?? '').split(' - ');
+                return {
+                  name: name.trim(),
+                  description: rest.join(' - ').trim() || undefined,
+                };
+              }) || undefined;
 
-        const cssProperties:
-          | schema.CssCustomProperty[]
-          | undefined = comp.styles?.length
-          ? comp.styles.map(s => ({
-              name: s.name,
-              description: s.docs || undefined,
-            }))
-          : undefined;
+        const cssProperties: schema.CssCustomProperty[] | undefined = comp.docsTags
+              .filter(t => t.name === 'cssprop')
+              .map(t => {
+                const [name, ...rest] = (t.text ?? '').split(' - ');
+                return {
+                  name: name.trim(),
+                  description: rest.join(' - ').trim() || undefined,
+                };
+              }) || undefined;;
 
         const elem: schema.CustomElement = {
           tagName: comp.tag,

--- a/packages/stencil-docs-target/src/convertToRaisins.ts
+++ b/packages/stencil-docs-target/src/convertToRaisins.ts
@@ -95,20 +95,30 @@ export function convertToGrapesJSMeta(docs: JsonDocs): schema.Module {
         const cssParts: schema.CssPart[] | undefined = comp.docsTags
               .filter(t => t.name === 'csspart')
               .map(t => {
-                const [name, ...rest] = (t.text ?? '').split(' - ');
+                const [name, description] = splitOnFirst(t.text ?? '', ' - ');
+                if (!name) {
+                  throw new Error(
+                    `Invalid @csspart tag on component "${comp.tag}" is missing a name.`
+                  );
+                }
                 return {
                   name: name.trim(),
-                  description: rest.join(' - ').trim() || undefined,
+                  description: description?.trim() || undefined,
                 };
               }) || undefined;
 
         const cssProperties: schema.CssCustomProperty[] | undefined = comp.docsTags
               .filter(t => t.name === 'cssprop')
               .map(t => {
-                const [name, ...rest] = (t.text ?? '').split(' - ');
+                const [name, description] = splitOnFirst(t.text ?? '', ' - ');
+                if (!name) {
+                  throw new Error(
+                    `Invalid @cssprop tag on component "${comp.tag}" is missing a name.`
+                  );
+                }
                 return {
                   name: name.trim(),
-                  description: rest.join(' - ').trim() || undefined,
+                  description: description?.trim() || undefined,
                 };
               }) || undefined;;
 


### PR DESCRIPTION
## Summary

Adds the wiring to author CSS inside the Raisins editor instead of forking components or post-processing HTML. Two surfaces:

1. **Per-instance override CSS** — select an element on the canvas, write CSS that applies to only that instance (stored on the element as `data-raisin-css`, scoped at render time via a `data-raisin-id` attribute selector).
2. **Document-wide CSS** — a single editable block whose rules can target any selector.

Both surfaces share a single derived managed `<style>` injected into the canvas iframe head; no imperative mutation of the document tree.

### Highlights

- **`@raisins/schema`** — new `CustomElement.cssParts` field and `CssPart` type.
- **`@raisins/stencil-docs-target`** — emits `cssParts` / `cssProperties` from Stencil's `@csspart` / `@cssprop` JSDoc tags.
- **`@raisins/core`** — `scopeStylesheet()` rewrites `:host`, `:host(<sel>)`, `::part(name)`, and bare selectors. Unit-tested via css-tree AST round-trip (10 tests).
- **`@raisins/react`**
  - `CssEditingMolecule` — derives the managed stylesheet from every element's `data-raisin-css`.
  - `StyleMolecule` + `StylePanel` — one editable section for the element itself (`:host`) plus one per declared `::part(name)`, with locally-controlled textareas so partial input never gets clobbered.
  - `DocumentCssMolecule` + `DocumentCssEditor` — page-wide editor.
  - Managed `<style data-raisin-managed>` is injected into the canvas iframe head.
  - Registers a generic `"css"` attribute widget for `uiWidget: "css"` opt-in.
- **Storybook** — new `Editor / CssEditing` story that loads kitchen-sink components via `@local`. Also fixes a pre-existing `jotai/utils` misimport in `SlotChildrenController.stories.tsx` that prevented Storybook from loading.

### Shadow DOM contract

Raisins does **not** pierce shadow DOM. Per-instance CSS targets `:host`, `::part()`, and inherited CSS custom properties — Shoelace/Mint's published styling contract. If a component is missing a stylable surface, the fix is to expose a new `::part`, not to bypass shadow encapsulation from Raisins.

### Companion branch

The kitchen-sink `<my-card>` is annotated with `@csspart header` / `@csspart body` in [`feat/my-card-csspart`](https://github.com/saasquatch/raisins/pull/new/feat/my-card-csspart) so the new Storybook story has parts to demonstrate. That branch is independent and can land separately.

## Test plan

- [ ] `cd packages/core && npm test` — scope transform unit tests pass.
- [ ] `cd packages/schema && npm run build` — `schema.json` regenerates with `cssParts`.
- [ ] `cd packages/stencil-docs-target && npm run build` — clean.
- [ ] Start the kitchen-sink dev server (`cd examples/my-kitchen-sink && npm run start:raisins`), then `cd packages/react && npm run storybook` and open **Editor / CssEditing**. (Requires the companion my-card branch for parts to show up.)
- [ ] Click the card on the canvas. Verify per-section textareas render for `:host`, `::part(header)`, `::part(body)`.
- [ ] Type `background: tomato; color: white` in the header section — confirm the card's header turns red live (proves `::part` pierces shadow DOM via the scope rewrite).
- [ ] Type `outline: 3px solid hotpink` in the `:host` section — confirm the outer card gets the outline (proves `:host` rewrites to the attribute selector).
- [ ] In Document CSS, write `my-card { display: none }` — confirm the card hides.
- [ ] Hand-edit `data-raisin-css` on the element (via DOM inspector) and reload — confirm the section textareas reflect the new values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)